### PR TITLE
removes the circular reference and adds the build:clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "webpack-dev-server",
     "lint": "eslint ./ --ext .ts,.tsx",
     "deploy:gh-pages": "node ./scripts/gh-pages.js",
-    "build": "rm -rf es && tsc -p ./tsconfig.build.es2015.json && tsc -p ./tsconfig.build.commonjs.json",
+    "build:clean": "rm -rf es lib *.tsbuildinfo",
+    "build": "yarn build:clean && tsc -p ./tsconfig.build.es2015.json && tsc -p ./tsconfig.build.commonjs.json",
     "build:example": "webpack --config ./webpack.config.js --prod"
   },
   "files": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 import { MapOptions } from 'leaflet'
-import { getCrsRd } from './utils'
+import getCrsRd from './utils/getCrsRd'
 
 export const DEFAULT_AMSTERDAM_MAPS_OPTIONS: MapOptions = {
   center: [52.3731081, 4.8932945],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/prefer-default-export
 export { default as getCrsRd } from './getCrsRd'
 export { default as useGetAddressFromLatLng } from './useGetAddressFromLatLng'
+export { default as fetchWithAbort } from './fetchWithAbort'


### PR DESCRIPTION
This PR:
- fixes a runtime circular reference utils -> constants
- improves the build:clean script  
- exports the fetchWithAbort function