### PR TITLE
Modify component, add dual-layer-toggle

### DIFF
--- a/packages/arm-core/src/components/BaseLayerToggle.tsx
+++ b/packages/arm-core/src/components/BaseLayerToggle.tsx
@@ -19,22 +19,13 @@ import {
 import BaseLayer from './BaseLayer'
 
 const AerialBackground = require('../../static/aerial-background.png')
-  .default as string
 const AerialBackgroundRetina = require('../../static/aerial-background@2.png')
-  .default as string
 const TopoBackground = require('../../static/topo-background.png')
-  .default as string
 const TopoBackgroundRetina = require('../../static/topo-background@2.png')
-  .default as string
 
 export enum BaseLayerType {
   Aerial = 'luchtfoto',
   Topo = 'topografie',
-}
-
-const BASE_LAYERS = {
-  [BaseLayerType.Aerial]: AERIAL_AMSTERDAM_LAYERS,
-  [BaseLayerType.Topo]: DEFAULT_AMSTERDAM_LAYERS,
 }
 
 const BASE_LAYER_STYLE = {
@@ -133,6 +124,13 @@ const BaseLayerToggle: React.FC<Props> = ({
   const didMount = useRef(false)
   const [toggleBaseLayerType, setToggleBaseLayerType] = useState(activeLayer)
 
+  const baseLayers = useMemo(() => {
+    return {
+      [BaseLayerType.Aerial]: aerialLayers,
+      [BaseLayerType.Topo]: topoLayers,
+    }
+  }, [aerialLayers, topoLayers])
+
   const [selectedLayer, setSelectedLayer] = useState({
     [BaseLayerType.Aerial]: aerialLayers[aerialDefaultIndex].urlTemplate,
     [BaseLayerType.Topo]: topoLayers[topoDefaultIndex].urlTemplate,
@@ -191,56 +189,58 @@ const BaseLayerToggle: React.FC<Props> = ({
         onClick={handleToggle}
         layerType={layerTypeForButton}
       />
-      <Menu
-        data-test="context-menu"
-        title="Actiemenu"
-        arrowIcon={<Ellipsis />}
-        selectElementForTouchScreen={
-          <>
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label
-              style={{ display: 'none' }}
-              htmlFor="arm-baselayer-toggle-select"
+      {baseLayers[toggleBaseLayerType].length > 1 && (
+        <Menu
+          data-test="context-menu"
+          title="Actiemenu"
+          arrowIcon={<Ellipsis />}
+          selectElementForTouchScreen={
+            <>
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label
+                style={{ display: 'none' }}
+                htmlFor="arm-baselayer-toggle-select"
+              >
+                Open menu
+              </label>
+              <ContextMenuSelect
+                name="context-menu"
+                id="arm-baselayer-toggle-select"
+                onChange={(e) => handleChange(e, currentAmsterdamLayers)}
+              >
+                {baseLayers[toggleBaseLayerType].map(({ id, label }) => (
+                  <option key={id} value={id}>
+                    {label}
+                  </option>
+                ))}
+              </ContextMenuSelect>
+            </>
+          }
+          position="bottom"
+        >
+          {baseLayers[toggleBaseLayerType].map(({ id, label, urlTemplate }) => (
+            <StyledContextMenuItem
+              key={id}
+              onClick={(e) => {
+                setSelectedLayer({
+                  ...selectedLayer,
+                  [toggleBaseLayerType]: urlTemplate,
+                })
+                e.currentTarget.blur()
+              }}
+              icon={
+                urlTemplate === selectedLayer[toggleBaseLayerType] ? (
+                  <CheckmarkIcon inline size={12}>
+                    <Checkmark />
+                  </CheckmarkIcon>
+                ) : null
+              }
             >
-              Open menu
-            </label>
-            <ContextMenuSelect
-              name="context-menu"
-              id="arm-baselayer-toggle-select"
-              onChange={(e) => handleChange(e, currentAmsterdamLayers)}
-            >
-              {BASE_LAYERS[toggleBaseLayerType].map(({ id, label }) => (
-                <option key={id} value={id}>
-                  {label}
-                </option>
-              ))}
-            </ContextMenuSelect>
-          </>
-        }
-        position="bottom"
-      >
-        {BASE_LAYERS[toggleBaseLayerType].map(({ id, label, urlTemplate }) => (
-          <StyledContextMenuItem
-            key={id}
-            onClick={(e) => {
-              setSelectedLayer({
-                ...selectedLayer,
-                [toggleBaseLayerType]: urlTemplate,
-              })
-              e.currentTarget.blur()
-            }}
-            icon={
-              urlTemplate === selectedLayer[toggleBaseLayerType] ? (
-                <CheckmarkIcon inline size={12}>
-                  <Checkmark />
-                </CheckmarkIcon>
-              ) : null
-            }
-          >
-            {label}
-          </StyledContextMenuItem>
-        ))}
-      </Menu>
+              {label}
+            </StyledContextMenuItem>
+          ))}
+        </Menu>
+      )}
       <BaseLayer baseLayer={selectedLayer[toggleBaseLayerType]} />
     </Wrapper>
   )

--- a/stories/src/ui/BaseLayerToggle.stories.mdx
+++ b/stories/src/ui/BaseLayerToggle.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Map, ViewerContainer, BaseLayerToggle } from '@datapunt/arm-core'
+import { Map, ViewerContainer, BaseLayerToggle, constants } from '@datapunt/arm-core'
 
 <Meta title="UI/BaseLayerToggle" component={BaseLayerToggle} />
 
@@ -11,6 +11,23 @@ import { Map, ViewerContainer, BaseLayerToggle } from '@datapunt/arm-core'
   <Story name="Default">
     <Map fullScreen>
       <ViewerContainer bottomLeft={<BaseLayerToggle />} />
+    </Map>
+  </Story>
+</Preview>
+
+## Dual layer toggle
+
+<Preview>
+  <Story name="Dual layer toggle">
+    <Map fullScreen>
+      <ViewerContainer
+        bottomLeft={
+          <BaseLayerToggle
+            aerialLayers={[constants.AERIAL_AMSTERDAM_LAYERS[0]]}
+            topoLayers={[constants.DEFAULT_AMSTERDAM_LAYERS[0]]}
+          />
+        }
+      />
     </Map>
   </Story>
 </Preview>

--- a/stories/src/ui/BaseLayerToggle.stories.mdx
+++ b/stories/src/ui/BaseLayerToggle.stories.mdx
@@ -1,5 +1,10 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Map, ViewerContainer, BaseLayerToggle, constants } from '@datapunt/arm-core'
+import {
+  Map,
+  ViewerContainer,
+  BaseLayerToggle,
+  constants,
+} from '@datapunt/arm-core'
 
 <Meta title="UI/BaseLayerToggle" component={BaseLayerToggle} />
 


### PR DESCRIPTION
The props of this component allows to pass aerialLayers and topLayers props. These props are not effective because the context menu's used the constant values supplied by the package.

This PR makes it possible to be able to only switch between provided layers to the component. Also if less than 1 of each typeof layer is passed, the context menu will be disabled.