### PR TITLE
Make panel title optional

### DIFF
--- a/packages/arm-core/src/components/MapPanel/MapPanelContent.tsx
+++ b/packages/arm-core/src/components/MapPanel/MapPanelContent.tsx
@@ -16,7 +16,7 @@ import {
 import MapDrawerContext, { Variant } from './MapPanelContext'
 
 export interface MapPanelContentProps {
-  title: string
+  title?: string
   subTitle?: string
   onClose?: () => void
   stackOrder?: number
@@ -28,6 +28,7 @@ const Header = styled.header`
   display: flex;
   width: 100%;
   padding: ${themeSpacing(4)};
+  padding-bottom: 0;
 `
 
 const SubTitleHeading = styled(Heading)`
@@ -112,7 +113,7 @@ const MapDrawerContentStyle = styled.div<{
 
 const Content = styled.div`
   width: 100%;
-  padding: ${themeSpacing(0, 4)};
+  padding: ${themeSpacing(4, 4, 0, 4)};
   overflow: auto;
   pointer-events: all;
 
@@ -169,7 +170,7 @@ const MapPanelContent: React.FC<MapPanelContentProps> = ({
   ...otherProps
 }) => {
   const { matchPositionWithSnapPoint, variant } = useContext(MapDrawerContext)
-
+  const showHeader = !!(title || onClose || subTitle)
   return (
     <MapDrawerContentStyle {...{ variant, stackOrder, animate }}>
       <StyledContainer
@@ -177,24 +178,32 @@ const MapPanelContent: React.FC<MapPanelContentProps> = ({
           matchPositionWithSnapPoint(SnapPoint.Halfway) ? '50vh' : '100vh'
         }
       >
-        <Header>
-          <div>
-            {subTitle && <SubTitleHeading as="h3">{subTitle}</SubTitleHeading>}
-            <Heading as="h4" styleAs="h1">
-              {title}
-            </Heading>
-          </div>
-          {onClose && (
-            <CloseButton
-              variant="blank"
-              title="Sluit"
-              type="button"
-              size={30}
-              onClick={onClose}
-              icon={<Close />}
-            />
-          )}
-        </Header>
+        {showHeader && (
+          <Header>
+            {(title || subTitle) && (
+              <div>
+                {subTitle && (
+                  <SubTitleHeading as="h3">{subTitle}</SubTitleHeading>
+                )}
+                {title && (
+                  <Heading as="h4" styleAs="h1">
+                    {title}
+                  </Heading>
+                )}
+              </div>
+            )}
+            {onClose && (
+              <CloseButton
+                variant="blank"
+                title="Sluit"
+                type="button"
+                size={30}
+                onClick={onClose}
+                icon={<Close />}
+              />
+            )}
+          </Header>
+        )}
         <Content {...otherProps}>{children}</Content>
       </StyledContainer>
     </MapDrawerContentStyle>

--- a/stories/src/examples/MapPanelExample.tsx
+++ b/stories/src/examples/MapPanelExample.tsx
@@ -144,7 +144,7 @@ const CustomMarker: React.FC<{
 }
 
 const MapLegendContent = ({ ...otherProps }) => (
-  <MapPanelContent title="Legenda" subTitle="Een kaartpaneel" {...otherProps}>
+  <MapPanelContent {...otherProps}>
     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab aperiam
     corporis culpa error et illum ipsa ipsam laudantium, maiores molestias non
     quaerat quasi qui temporibus voluptates. Adipisci dolore odit placeat sint
@@ -257,7 +257,15 @@ const Results: React.FC<ResultProps> = ({
   )
 }
 
-const MapPanelExample: React.FC = () => {
+interface MapPanelExampleProps {
+  panelTitle?: string
+  panelSubTitle?: string
+}
+
+const MapPanelExample: React.FC<MapPanelExampleProps> = ({
+  panelTitle,
+  panelSubTitle,
+}) => {
   const [currentLatLng, setCurrentLatLng] = useState<LatLng | null>(null)
   const [currentOverlay, setCurrentOverlay] = useState<Overlay>(Overlay.None)
   const [showDesktopVariant] = hooks.useMatchMedia({ minBreakpoint: 'tabletM' })
@@ -284,6 +292,8 @@ const MapPanelExample: React.FC = () => {
           />
           {currentOverlay === Overlay.Legend && (
             <MapLegendContent
+              title={panelTitle}
+              subTitle={panelSubTitle}
               stackOrder={3}
               animate
               onClose={() => {
@@ -302,7 +312,7 @@ const MapPanelExample: React.FC = () => {
               }}
             />
           )}
-          <MapLegendContent />
+          <MapLegendContent title={panelTitle} subTitle={panelSubTitle} />
         </Element>
         <ViewerContainerWithMapDrawerOffset
           {...{

--- a/stories/src/ui/MapPanel.stories.mdx
+++ b/stories/src/ui/MapPanel.stories.mdx
@@ -14,7 +14,7 @@ This component could be used to show results of actions that where performed on 
 <Preview>
   <Story name="Default">
     <Map fullScreen>
-      <MapPanelExample />
+      <MapPanelExample panelTitle="Legenda" panelSubTitle="Een kaartpaneel" />
     </Map>
   </Story>
 </Preview>
@@ -30,6 +30,18 @@ This component could be used to show results of actions that where performed on 
         defaultViewport: 'iphone6',
       },
     }}
+  >
+    <Map fullScreen>
+      <MapPanelExample panelTitle="Legenda" panelSubTitle="Een kaartpaneel" />
+    </Map>
+  </Story>
+</Preview>
+
+## Without header
+
+<Preview>
+  <Story
+    name="Without header"
   >
     <Map fullScreen>
       <MapPanelExample />


### PR DESCRIPTION
This PR makes it possible to leave out the MapPanelContent.title which makes it possible to have Panels without titles.

We might also want to take a different approach where the header component is made standalone.

```
<MapPanelContent>
    <MapPanelContentHeader title="Legenda" subTitle="Kaartpanel" />
    <MapPanelContentInner>Text... components etc.</MapPanelContentInner>
</MapPanelContent>
```

or even:

```
<MapPanelContent>
    <MapPanelContentHeader>
      <Heading as="h4" styleAs="h1">Een kaartpaneel</Heading>
      <Heading as="h3">Legenda</Heading>
    </MapPanelContentHeader>
    <MapPanelContentInner>Text... components etc.</MapPanelContentInner>
</MapPanelContent>
```

What do you think?