### PR TITLE
Change marker generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Prefix the change with one of these keywords:
 - Fixed: for any bug fixes.
 - Security: in case of vulnerabilities.
 
-## [0.3.6] (unreleased)
+## [0.4.0] (unreleased)
 - Changed: MarkerClusterGroup has a breaking change. The L.MarkerClusterGroup layer is constructed outside of the component. 
 - Added: MarkerClusterGroup accepts events for the L.MarkerClusterGroup layer instead of individual markers
 - Added: MarkerClusterGroup now has a setInstance method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Prefix the change with one of these keywords:
 - Fixed: for any bug fixes.
 - Security: in case of vulnerabilities.
 
+## [0.3.6]
+- Changed: MarkerClusterGroup has a breaking change. The L.MarkerClusterGroup layer is constructed outside of the component. 
+- Added: MarkerClusterGroup accepts events for the L.MarkerClusterGroup layer instead of individual markers
+- Added: MarkerClusterGroup now has a setInstance method
+
 ## [0.3.5]
 - Changed: Marker component now accepts the more generic LatLngExpression instead of only a LatLng
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Prefix the change with one of these keywords:
 - Fixed: for any bug fixes.
 - Security: in case of vulnerabilities.
 
-## [0.3.6]
+## [0.3.6] (unreleased)
 - Changed: MarkerClusterGroup has a breaking change. The L.MarkerClusterGroup layer is constructed outside of the component. 
 - Added: MarkerClusterGroup accepts events for the L.MarkerClusterGroup layer instead of individual markers
 - Added: MarkerClusterGroup now has a setInstance method

--- a/packages/arm-cluster/package.json
+++ b/packages/arm-cluster/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/Amsterdam/amsterdam-react-maps/issues"
   },
-  "version": "0.3.5",
+  "version": "0.4.0",
   "main": "lib/index.js",
   "module": "es/index.js",
   "files": [

--- a/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
+++ b/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
@@ -59,11 +59,15 @@ export function createClusterMarkers({
 type MarkerClusterGroupProps = {
   markers: Marker[]
   optionsOverrides?: MarkerClusterGroupOptions
+  events?: LeafletEventHandlerFnMap
+  setInstance?: (clusterLayer: L.MarkerClusterGroup | null) => void
 }
 
 const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
   markers,
   optionsOverrides,
+  events,
+  setInstance,
 }) => {
   const mapInstance = useMapInstance()
 
@@ -95,6 +99,32 @@ const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
     }
     return null
   }, [mapInstance, optionsOverrides])
+
+  useEffect(() => {
+    if (setInstance && markerClusterGroup) {
+      setInstance(markerClusterGroup)
+    }
+    return () => {
+      if (setInstance && markerClusterGroup) {
+        setInstance(null)
+      }
+    }
+  }, [setInstance, markerClusterGroup])
+
+  useEffect(() => {
+    if (markerClusterGroup && events) {
+      Object.entries(events).forEach(([event, eventHandler]) => {
+        markerClusterGroup.on(event, eventHandler)
+      })
+    }
+    return () => {
+      if (markerClusterGroup && events) {
+        Object.entries(events).forEach(([event, eventHandler]) => {
+          markerClusterGroup.off(event, eventHandler)
+        })
+      }
+    }
+  }, [events, markerClusterGroup])
 
   useEffect(() => {
     if (mapInstance && markerClusterGroup) {

--- a/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
+++ b/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
@@ -60,7 +60,7 @@ type MarkerClusterGroupProps = {
   markers: Marker[]
   optionsOverrides?: MarkerClusterGroupOptions
   events?: LeafletEventHandlerFnMap
-  setInstance?: (clusterLayer: L.MarkerClusterGroup | null) => void
+  setInstance?: (clusterLayer: L.MarkerClusterGroup | undefined) => void
 }
 
 const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
@@ -97,7 +97,7 @@ const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
         ...(optionsOverrides || {}),
       })
     }
-    return null
+    return undefined
   }, [mapInstance, optionsOverrides])
 
   useEffect(() => {
@@ -106,7 +106,7 @@ const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
     }
     return () => {
       if (setInstance && markerClusterGroup) {
-        setInstance(null)
+        setInstance(undefined)
       }
     }
   }, [setInstance, markerClusterGroup])

--- a/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
+++ b/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
@@ -1,17 +1,15 @@
 import React, { useEffect, useMemo } from 'react'
 import { useMapInstance } from '@datapunt/react-maps'
 import L, {
-  Icon,
+  MarkerClusterGroupOptions,
+  Marker,
   LatLngTuple,
   LeafletEventHandlerFnMap,
-  MarkerClusterGroupOptions,
 } from 'leaflet'
 import 'leaflet.markercluster'
 import { createGlobalStyle } from 'styled-components'
 import { icons } from '@datapunt/arm-core'
 import { themeColor } from '@datapunt/asc-ui'
-
-const { defaultIcon } = icons
 
 const Styles = createGlobalStyle`
   .arm__icon--clustergroup-default {
@@ -32,17 +30,39 @@ const Styles = createGlobalStyle`
   }
 `
 
-type Props = {
+type CreateClusterMarkersFnProps = {
   markers: LatLngTuple[]
   events?: LeafletEventHandlerFnMap
-  markerIcon?: Icon
+}
+
+// The default function simply uses an array of LatLngTuples with the default marker icon
+export function createClusterMarkers({
+  markers,
+  events,
+}: CreateClusterMarkersFnProps) {
+  const markerObjects: Marker[] = []
+
+  for (let i = 0; i < markers.length; i += 1) {
+    const [lat, lng] = markers[i]
+    const marker = L.marker(new L.LatLng(lat, lng), {
+      icon: icons.defaultIcon,
+    })
+    if (events) {
+      marker.on(events)
+    }
+    markerObjects.push(marker)
+  }
+
+  return markerObjects
+}
+
+type MarkerClusterGroupProps = {
+  markers: Marker[]
   optionsOverrides?: MarkerClusterGroupOptions
 }
 
-const MarkerClusterGroup: React.FC<Props> = ({
+const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
   markers,
-  markerIcon = defaultIcon,
-  events,
   optionsOverrides,
 }) => {
   const mapInstance = useMapInstance()
@@ -80,17 +100,7 @@ const MarkerClusterGroup: React.FC<Props> = ({
     if (mapInstance && markerClusterGroup) {
       // Bulk remove all the existing layers
       markerClusterGroup.clearLayers()
-      for (let i = 0; i < markers.length; i += 1) {
-        const [lat, lng] = markers[i]
-        const icon = markerIcon
-        // NOTE: It might be more performant to use pre-instantiated markers rather than creating new ones on every incoming markers payload.
-        const marker = L.marker(new L.LatLng(lat, lng), { icon })
-        if (events) {
-          marker.on(events)
-        }
-        markerClusterGroup.addLayer(marker)
-      }
-
+      markerClusterGroup.addLayers(markers)
       if (!mapInstance.hasLayer(markerClusterGroup)) {
         mapInstance.addLayer(markerClusterGroup)
       }

--- a/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
+++ b/packages/arm-cluster/src/components/MarkerClusterGroup.tsx
@@ -71,18 +71,22 @@ const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
 }) => {
   const mapInstance = useMapInstance()
 
+  // Create the markerClusterGroup instance
   const markerClusterGroup = useMemo(() => {
-    if (mapInstance) {
-      return L.markerClusterGroup({
-        spiderfyOnMaxZoom: false,
-        showCoverageOnHover: false,
-        zoomToBoundsOnClick: true,
-        maxClusterRadius: 50,
-        chunkedLoading: true,
-        disableClusteringAtZoom: 16,
-        iconCreateFunction: (marker) =>
-          L.divIcon({
-            html: `
+    if (!mapInstance) {
+      return undefined
+    }
+
+    return L.markerClusterGroup({
+      spiderfyOnMaxZoom: false,
+      showCoverageOnHover: false,
+      zoomToBoundsOnClick: true,
+      maxClusterRadius: 50,
+      chunkedLoading: true,
+      disableClusteringAtZoom: 16,
+      iconCreateFunction: (marker) =>
+        L.divIcon({
+          html: `
             <div
               class="arm__icon-text"
               aria-label="Cluster met ${marker.getChildCount()} onderdelen"
@@ -90,55 +94,60 @@ const MarkerClusterGroup: React.FC<MarkerClusterGroupProps> = ({
               ${marker.getChildCount()}
             </div>
             `,
-            className: 'arm__icon--clustergroup-default',
-            iconSize: L.point(39, 39),
-            iconAnchor: L.point(19, 19),
-          }),
-        ...(optionsOverrides || {}),
-      })
-    }
-    return undefined
+          className: 'arm__icon--clustergroup-default',
+          iconSize: L.point(39, 39),
+          iconAnchor: L.point(19, 19),
+        }),
+      ...(optionsOverrides || {}),
+    })
   }, [mapInstance, optionsOverrides])
 
+  // Call back with the markerClusterGroup
   useEffect(() => {
-    if (setInstance && markerClusterGroup) {
-      setInstance(markerClusterGroup)
+    if (!setInstance || !markerClusterGroup) {
+      return undefined
     }
+
+    setInstance(markerClusterGroup)
+
     return () => {
-      if (setInstance && markerClusterGroup) {
-        setInstance(undefined)
-      }
+      setInstance(undefined)
     }
   }, [setInstance, markerClusterGroup])
 
+  // Add the layer events to markerClusterGroup
   useEffect(() => {
-    if (markerClusterGroup && events) {
-      Object.entries(events).forEach(([event, eventHandler]) => {
-        markerClusterGroup.on(event, eventHandler)
-      })
+    if (!markerClusterGroup || !events) {
+      return undefined
     }
+
+    Object.entries(events).forEach(([event, eventHandler]) => {
+      markerClusterGroup.on(event, eventHandler)
+    })
+
     return () => {
-      if (markerClusterGroup && events) {
-        Object.entries(events).forEach(([event, eventHandler]) => {
-          markerClusterGroup.off(event, eventHandler)
-        })
-      }
+      Object.entries(events).forEach(([event, eventHandler]) => {
+        markerClusterGroup.off(event, eventHandler)
+      })
     }
   }, [events, markerClusterGroup])
 
+  // Add / Remove Markers to the markerClusterGroup
   useEffect(() => {
-    if (mapInstance && markerClusterGroup) {
-      // Bulk remove all the existing layers
-      markerClusterGroup.clearLayers()
-      markerClusterGroup.addLayers(markers)
-      if (!mapInstance.hasLayer(markerClusterGroup)) {
-        mapInstance.addLayer(markerClusterGroup)
-      }
+    if (!mapInstance || !markerClusterGroup) {
+      return undefined
     }
+
+    // Bulk remove all the existing layers
+    markerClusterGroup.clearLayers()
+    markerClusterGroup.addLayers(markers)
+
+    if (!mapInstance.hasLayer(markerClusterGroup)) {
+      mapInstance.addLayer(markerClusterGroup)
+    }
+
     return () => {
-      if (mapInstance && markerClusterGroup) {
-        mapInstance.removeLayer(markerClusterGroup)
-      }
+      mapInstance.removeLayer(markerClusterGroup)
     }
   }, [mapInstance, markerClusterGroup, markers])
 

--- a/packages/arm-cluster/src/index.ts
+++ b/packages/arm-cluster/src/index.ts
@@ -1,2 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as MarkerClusterGroup } from './components/MarkerClusterGroup'
+export {
+  default as MarkerClusterGroup,
+  createClusterMarkers,
+} from './components/MarkerClusterGroup'

--- a/packages/arm-core/src/components/MapPanel/MapPanelContent.tsx
+++ b/packages/arm-core/src/components/MapPanel/MapPanelContent.tsx
@@ -6,7 +6,7 @@ import {
   themeColor,
   themeSpacing,
 } from '@datapunt/asc-ui'
-import React, { useContext } from 'react'
+import React, { useContext, ReactNode } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import {
   PANEL_HANDLE_HEIGHT,
@@ -16,8 +16,8 @@ import {
 import MapDrawerContext, { Variant } from './MapPanelContext'
 
 export interface MapPanelContentProps {
-  title?: string
-  subTitle?: string
+  title?: ReactNode
+  subTitle?: ReactNode
   onClose?: () => void
   stackOrder?: number
   variant?: Variant

--- a/stories/src/examples/MarkerFilters.tsx
+++ b/stories/src/examples/MarkerFilters.tsx
@@ -48,7 +48,7 @@ function createDatasetMarkers(datasetId: string, coordinates: LatLngTuple[]) {
 
 interface MarkerFiltersProps {
   markersSource: L.LatLngTuple[]
-  clusterComponent: (markers: any) => ReactNode
+  clusterComponent: (markers: L.Marker[]) => ReactNode
 }
 
 export default function MarkerFilters({

--- a/stories/src/examples/MarkerFilters.tsx
+++ b/stories/src/examples/MarkerFilters.tsx
@@ -1,12 +1,7 @@
 import React, { ReactNode, useMemo, useState, useCallback } from 'react'
 import { Label, Checkbox, themeColor, themeSpacing } from '@datapunt/asc-ui'
-import styled from 'styled-components'
-import L from 'leaflet'
-
-interface MarkerFiltersProps {
-  markers: L.LatLngTuple[]
-  clusterComponent: (markers: any) => ReactNode
-}
+import styled, { createGlobalStyle } from 'styled-components'
+import L, { Marker, LatLngTuple } from 'leaflet'
 
 const UnstyledOl = styled.ol`
   margin: 0;
@@ -22,41 +17,84 @@ const Panel = styled.div`
 
 const setCount = 6
 
+const MarkerStyles = createGlobalStyle`
+  .custom-marker {
+    background-color: ${themeColor('primary')};
+    border-radius: 50%;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    cursor: zoom-in;
+    text-transform: uppercase;
+  }
+`
+
+function createDatasetMarkers(datasetId: string, coordinates: LatLngTuple[]) {
+  return coordinates.map(([lat, lng]) => {
+    const html = `<span aria-label="Marker uit dataset ${datasetId} op location lat: ${lat} lng: ${lng}">${datasetId}</span>`
+    const markerObject = L.marker(new L.LatLng(lat, lng), {
+      icon: L.divIcon({
+        html,
+        className: `custom-marker custom-marker--${datasetId}`,
+        iconSize: L.point(20, 20),
+        iconAnchor: L.point(10, 10),
+      }),
+    })
+    return markerObject
+  })
+}
+
+interface MarkerFiltersProps {
+  markersSource: L.LatLngTuple[]
+  clusterComponent: (markers: any) => ReactNode
+}
+
 export default function MarkerFilters({
-  markers,
+  markersSource,
   clusterComponent,
 }: MarkerFiltersProps) {
-  const [activeDatasets, setActiveDataset] = useState([0, 1, 2])
+  const [activeDatasets, setActiveDataset] = useState(['a', 'b', 'c'])
 
+  // Create some fake datasets from the source makers
   const markerSets = useMemo(() => {
     const datasets = []
+    const setLen = markersSource.length / setCount
 
     for (let i = 0; i < setCount; i += 1) {
+      // Divide the markerSource into $setCount parts
+      const start = i * setLen
+      const id = String.fromCharCode(97 + i)
       datasets.push({
-        id: i,
-        title: `Dataset ${i + 1}`,
-        markers,
-        isActive: false,
+        id,
+        title: `Dataset ${id}`,
+        markers: createDatasetMarkers(
+          id,
+          markersSource.slice(start, start + setLen),
+        ),
       })
     }
     return datasets
-  }, [markers])
+  }, [markersSource])
 
+  // Concat the markers from the filtered datasets
   const markersFiltered = useMemo(() => {
     // eslint-disable-next-line no-shadow
-    let markersFiltered: MarkerFiltersProps['markers'] = []
-    const setLen = markers.length / setCount
+    const markersFiltered: Marker[] = []
+
     for (let i = 0; i < activeDatasets.length; i += 1) {
-      const start = activeDatasets[i] * setLen
-      markersFiltered = markersFiltered.concat(
-        markers.slice(start, start + setLen),
-      )
+      const markerSet = markerSets.find(({ id }) => id === activeDatasets[i])
+      if (markerSet) {
+        markersFiltered.push(...markerSet.markers)
+      }
     }
     return markersFiltered
-  }, [markers, activeDatasets])
+  }, [markerSets, activeDatasets])
 
+  // Update the active datasets state
   const onChange = useCallback(
-    (markerSetId: number) => {
+    (markerSetId: string) => {
       const updatedDatasets = activeDatasets.includes(markerSetId)
         ? activeDatasets.filter((id) => id !== markerSetId)
         : activeDatasets.concat(markerSetId)
@@ -81,6 +119,7 @@ export default function MarkerFilters({
           </li>
         ))}
       </UnstyledOl>
+      <MarkerStyles />
       {clusterComponent(markersFiltered)}
     </Panel>
   )

--- a/stories/src/other/MarkerCluster.stories.mdx
+++ b/stories/src/other/MarkerCluster.stories.mdx
@@ -25,13 +25,16 @@ For more info and available options, check out (https://github.com/Leaflet/Leafl
     <Map fullScreen>
       <ViewerContainer bottomRight={<Zoom />} />
       <MarkerClusterGroup
-        markers={createClusterMarkers({ markers, events: {
-          click: (e) => {
-            window.alert(
-              `Marker clicked!, Lat: ${e.latlng.lat}, Lng: ${e.latlng.lng}`,
-            )
+        markers={createClusterMarkers({
+          markers,
+          events: {
+            click: (e) => {
+              window.alert(
+                `Marker clicked!, Lat: ${e.latlng.lat}, Lng: ${e.latlng.lng}`,
+              )
+            },
           },
-        }})}
+        })}
       />
       <BaseLayer />
     </Map>

--- a/stories/src/other/MarkerCluster.stories.mdx
+++ b/stories/src/other/MarkerCluster.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 import { withKnobs, boolean, number } from '@storybook/addon-knobs'
 import { Map, ViewerContainer, Zoom, BaseLayer } from '@datapunt/arm-core'
-import { MarkerClusterGroup } from '@datapunt/arm-cluster'
+import { MarkerClusterGroup, createClusterMarkers } from '@datapunt/arm-cluster'
 import MarkerFilters from '../examples/MarkerFilters'
 import markers from '../stubs/markers.json'
 
@@ -25,14 +25,13 @@ For more info and available options, check out (https://github.com/Leaflet/Leafl
     <Map fullScreen>
       <ViewerContainer bottomRight={<Zoom />} />
       <MarkerClusterGroup
-        events={{
+        markers={createClusterMarkers({ markers, events: {
           click: (e) => {
             window.alert(
               `Marker clicked!, Lat: ${e.latlng.lat}, Lng: ${e.latlng.lng}`,
             )
           },
-        }}
-        markers={markers}
+        }})}
       />
       <BaseLayer />
     </Map>
@@ -64,23 +63,23 @@ For more info and available options, check out (https://github.com/Leaflet/Leafl
             step: 1,
           }),
         }}
-        markers={markers}
+        markers={createClusterMarkers({ markers })}
       />
       <BaseLayer />
     </Map>
   </Story>
 </Preview>
 
-## With marker filtering
+## With marker filtering and custom markers
 
 <Preview>
-  <Story name="With marker filtering">
+  <Story name="With marker filtering and custom markers">
     <Map fullScreen>
       <ViewerContainer
         bottomRight={<Zoom />}
         bottomLeft={
           <MarkerFilters
-            markers={markers}
+            markersSource={markers}
             clusterComponent={(markersFiltered) => (
               <MarkerClusterGroup markers={markersFiltered} />
             )}


### PR DESCRIPTION
During the process of implementing the MarkerClusterGroup component into a Map component, I came across a few things I'd like to improve. This is mainly about the place where the `L.Marker`s are constructed. I've separated the marker construction from the component so customized markers can be used.

This is a breaking change because the layer data has to be created outside of the component. The component will not just generate the layer from a bunch of `LatLngTuple[]`

Also I've added the options to pass events to add to the clusterLayer and a setInstance method for even more flexibility.