### PR TITLE
Pass other props to the DrawTool down into the component hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ Prefix the change with one of these keywords:
 - Security: in case of vulnerabilities.
 
 ## UNRELEASED
-- Removed: **BREAKING** onInitLayers and unused isOpen props on draw tool
-- Added: onEndInitialItems prop for draw tool
+- Removed: **BREAKING** unused props in several components 
+- Removed: **BREAKING** `onInitLayers` and unused `isOpen` props on draw tool
+- Added: `onEndInitialItems` prop for draw tool
+- Added: All components exported from `@amsterdam/arm-draw` now also export their respective prop types
+- Changed: `DrawTool` component will now pass along other props down the component hierarchy
 
 ## [0.5.1]
 - Changed: Update React Maps to version 0.12.0

--- a/packages/arm-draw/src/components/DrawTool/DrawTool.tsx
+++ b/packages/arm-draw/src/components/DrawTool/DrawTool.tsx
@@ -4,7 +4,7 @@ import { ascDefaultTheme, themeColor } from '@amsterdam/asc-ui'
 import { useMapInstance } from '@amsterdam/react-maps'
 import L, { LayerEvent, LeafletKeyboardEvent } from 'leaflet'
 import 'leaflet-draw'
-import { useEffect, useMemo, useState } from 'react'
+import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 import { createGlobalStyle } from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 import DrawToolControls from './DrawToolControls'
@@ -41,7 +41,7 @@ L.Edit.PolyVerticesEdit = L.Edit.PolyVerticesEdit.extend({
   },
 })
 
-type Props = {
+export interface DrawToolProps {
   onDrawStart?: (layer: ExtendedLayer) => void
   onDrawEnd?: (layer: ExtendedLayer) => void
   onClose?: () => void
@@ -53,7 +53,7 @@ type Props = {
   disablePolylineButton?: boolean
 }
 
-const DrawTool: React.FC<Props> = ({
+const DrawTool: FunctionComponent<DrawToolProps> = ({
   onDelete,
   onDrawStart,
   onDrawEnd,
@@ -63,6 +63,7 @@ const DrawTool: React.FC<Props> = ({
   onClose,
   disablePolygonButton,
   disablePolylineButton,
+  ...otherProps
 }) => {
   const [inEditMode, setInEditMode] = useState(false)
   const [inCreateMode, setInCreateMode, inCreateModeRef] = useStateRef(false)
@@ -253,6 +254,7 @@ const DrawTool: React.FC<Props> = ({
         onClose={onClose}
         disablePolygonButton={disablePolygonButton}
         disablePolylineButton={disablePolylineButton}
+        {...otherProps}
       />
     </>
   )

--- a/packages/arm-draw/src/components/DrawTool/DrawToolControls.tsx
+++ b/packages/arm-draw/src/components/DrawTool/DrawToolControls.tsx
@@ -93,7 +93,6 @@ export interface DrawToolControlsProps {
   inEditMode: boolean
   inDrawMode: boolean
   onClose?: () => void
-  show?: boolean
   disablePolygonButton?: boolean
   disablePolylineButton?: boolean
 }
@@ -108,8 +107,9 @@ const DrawToolControls: FunctionComponent<DrawToolControlsProps> = ({
   onClose,
   disablePolygonButton,
   disablePolylineButton,
+  ...otherProps
 }) => (
-  <DrawToolStyle orientation={orientation}>
+  <DrawToolStyle orientation={orientation} {...otherProps}>
     <ToolButton
       title={TOGGLE_BUTTON_TITLE}
       size={44}

--- a/packages/arm-draw/src/components/DrawTool/index.ts
+++ b/packages/arm-draw/src/components/DrawTool/index.ts
@@ -1,1 +1,1 @@
-export { default } from './DrawTool'
+export { default, DrawToolProps } from './DrawTool'

--- a/packages/arm-draw/src/index.ts
+++ b/packages/arm-draw/src/index.ts
@@ -1,17 +1,11 @@
-import DrawTool from './components/DrawTool/DrawTool'
-import DrawToolControls from './components/DrawTool/DrawToolControls'
-import DrawToolOpenButton from './components/DrawTool/DrawToolOpenButton'
-import {
-  PolygonType,
-  PolylineType,
-  ExtendedLayer,
-} from './components/DrawTool/types'
-
+export { default as DrawTool, DrawToolProps } from './components/DrawTool'
 export {
-  DrawTool,
-  DrawToolControls,
-  DrawToolOpenButton,
+  default as DrawToolControls,
+  DrawToolControlsProps,
+} from './components/DrawTool/DrawToolControls'
+export { default as DrawToolOpenButton } from './components/DrawTool/DrawToolOpenButton'
+export {
   ExtendedLayer,
   PolygonType,
   PolylineType,
-}
+} from './components/DrawTool/types'


### PR DESCRIPTION
Also changes the following
- Remove unused props in several components
- Export all prop types together with exported components